### PR TITLE
Fix typos and grammar mistakes in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,37 @@
 
 **Status:** Stage 1
 
-This proposal describes adding a standard library to the JavaScript that holds a set of API's that can be used at runtime. It also describes how the standard library can be used by developers, what API's could be part of the standard library and how it can be extended/evolved over time.
+This proposal describes adding a standard library to JavaScript that holds a set of APIs that can be used at runtime. It also describes how the standard library can be used by developers, what APIs could be part of the standard library and how it can be extended/evolved over time.
 
 ## Motivation
 
-When using other programming languages the developer gets the core features defined by the language (syntax, operators, primitive types etc.) and usually a (sometimes exhaustive) standard library that can be leveraged for common functionality. These languages can make certain assumptions on the environment the code is run in like which language features are supported and what API's are available in the standard library.
+When using other programming languages the developer gets the core features defined by the language (syntax, operators, primitive types etc.) and usually a (sometimes exhaustive) standard library that can be leveraged for common functionality. These languages can make certain assumptions on the environment the code is run in like which language features are supported and what APIs are available in the standard library.
 
-Because of the distributed nature of the Web Platform and JavaScript code running on varying clients these assumptions cannot be made when programming for the Web. Code has to be downloaded to clients, incurring a network and parse cost and only after the code is running can features be detected in a (sometimes) cumbersome way. This results in pages or applications including libraries with abstracted common functionality (jQuery, lodash, ramda), libraries to do feature detection and polyfilling (core-js et all) or compiling down to the lowest common feature set for their targeted users (using Typescript or Babel).
+Because of the distributed nature of the Web Platform and JavaScript code running on varying clients, these assumptions cannot be made when programming for the Web. Code has to be downloaded to clients, incurring a network and parse cost and only after the code is running can features be detected in a (sometimes) cumbersome way. This results in pages or applications including libraries with abstracted common functionality (jQuery, Lodash, Ramda), libraries to do feature detection and polyfilling (core-js, et al) or compiling down to the lowest common feature set for their targeted users (using TypeScript or Babel).
 
-These are all detremental for both the developer and the end user. Evolving the JavaScript language through the prototype chain adding new (standard library) methods can become problematic over time forcing a fallback to less ideal features because of web compatibility issues.
+These are all detrimental for both the developer and the end user. Evolving the JavaScript language through the prototype chain adding new (standard library) methods can become problematic over time forcing a fallback to less ideal features because of web compatibility issues.
 
 ## Benefits
 
-### **Availablity**
+### **Availability**
 
 Pages and applications don't have to include shared libraries anymore which helps with download size and speed.
 
 ### **Standardization**
 
-With the introduction of a standard library developers will get a well defined API that does not have to be incuded with their pages or application. The functionality of the standard libary will have gone through a standardization track and will have well defined API and behavior.
+With the introduction of a standard library developers will get a well-defined API that does not have to be included with their pages or application. The functionality of the standard library will have gone through a standardization track and will have well-defined APIs and behavior.
 
 ### **Extensibility**
 
 > FIXME This point needs work
 
-The standard library provides a great location for future extensions to the language and the toolkit available to developers. Because the functionality is added to a reserved space there is less chance of conflicts and all addtions have gone through a standardization track. It also provides a space where features can be developed that are not bound to the prototype, a generic `len` or `map` function for example that works on multiple types.
+The standard library provides a great location for future extensions to the language and the toolkit available to developers. Because the functionality is added to a reserved space there is less chance of conflicts and all additions have gone through a standardization track. It also provides a space where features can be developed that are not bound to the prototype, a generic `len` or `map` function for example that works on multiple types.
 
-The standard library furthermore has versioning build into it to avoid conflicts.
+The standard library furthermore has versioning built into it to avoid conflicts.
 
 ### **Fallback Mechanism**
 
-Importing features from the standard library has a fallback mechanism that can be used to override existing features if the version does not match or provide entire implementations when they are not available.The standard library can facilitate in feature detected to avoid cumbersome runtime checks (using error handling for example).
+Importing features from the standard library has a fallback mechanism that can be used to override existing features if the version does not match or provide entire implementations when they are not available. The standard library can facilitate in feature detected to avoid cumbersome runtime checks (using error handling for example).
 
 ### **Speed**
 
@@ -40,7 +40,7 @@ Features need to be explicitly imported from the standard library when used, usi
 
 > Question: Is this a weak argument? Engines already do lazy startup shenanigans
 
-Some standard library functions can be done in regular JavaScript, which is currently already the case. Moving functionality from external libraries (like lodash or ramda) allows them to tap into native code (C++) for heavy lifting and performance consious code.
+Some standard library functions can be done in regular JavaScript, which is currently already the case. Moving functionality from external libraries (like Lodash or Ramda) allows them to tap into native code (C++) for heavy lifting and performance-conscious code.
 
 Pages and applications furthermore don't have to include shared libraries anymore which helps with download speed and parse speed.
 
@@ -49,7 +49,7 @@ Pages and applications furthermore don't have to include shared libraries anymor
 - A namespace must be reserved
 - Prototypes of imported objects are frozen
 
-Still explorating:
+Still exploring:
 
 - Some form of versioning must be supported to avoid conflicts
 - There must be a way to provide fallback implementation (polyfilling)
@@ -82,7 +82,7 @@ const d = new Date(2018, 7, 1);
 
 > Describe that the prototype is frozen, and what we mean by that
 
-It's our intent that modules in the standard library are generally non effectfull (as a policy) evne though the are no limitation in the spec that enforce this.
+It's our intent that modules in the standard library are pure (free from side-effects) as a policy, even though there are no limitations in the spec to enforce this.
 
 ### Generic Functions
 
@@ -92,7 +92,7 @@ The advantage of using regular imports is that it allows the development of more
 - `map`
 
 ```js
-import{ len, map } from "std:builtins";
+import { len, map } from "std:builtins";
 
 const ar = [1, 2, 3];
 const st = new Set([4, 5, 6, 7]);
@@ -119,5 +119,3 @@ This topic has been talked about a lot in the past. There has been some recent a
 
 - <https://github.com/drufball/layered-apis>
 - <https://github.com/tc39/ecma262/issues/395>
-
- 


### PR DESCRIPTION
Supersedes #4.

Note there's only one typo (line 35) which I left intact...

> The standard library can ***facilitate in feature detected***  to avoid cumbersome runtime checks

... because I'm not sure what the intended meaning is. It could mean

1. _"The standard library can facilitate feature detection"_,
Or
2. _"The standard library can augment detected features"_,

There's also a lot of redundant language which can be removed, which repeats what's already implied by context (or already covered by a previous paragraph). I won't hassle you with subjective proof-reading (especially when I don't agree with this proposal myself).
